### PR TITLE
Changed to support partitions with id step of 1.

### DIFF
--- a/sql/functions/create_id_function.sql
+++ b/sql/functions/create_id_function.sql
@@ -112,7 +112,7 @@ IF v_type = 'id-static' THEN
                 RETURN NEW;
             END IF;
             v_current_partition_id := NEW.'||v_control||' - (NEW.'||v_control||' % '||v_part_interval||');
-            IF (NEW.'||v_control||' % '||v_part_interval||') > ('||v_part_interval||' / 2) THEN
+            IF (NEW.'||v_control||' % '||v_part_interval||') >= ('||v_part_interval||' / 2) THEN
                 v_id_position := (length(v_last_partition) - position(''p_'' in reverse(v_last_partition))) + 2;
                 v_next_partition_id := (substring(v_last_partition from v_id_position)::bigint) + '||v_part_interval||';
                 WHILE ((v_next_partition_id - v_current_partition_id) / '||v_part_interval||') <= '||v_premake||' LOOP 
@@ -150,7 +150,7 @@ ELSIF v_type = 'id-dynamic' THEN
         IF TG_OP = ''INSERT'' THEN 
             v_current_partition_id := NEW.'||v_control||' - (NEW.'||v_control||' % '||v_part_interval||');
             v_current_partition_name := @extschema@.check_name_length('''||v_parent_tablename||''', '''||v_parent_schema||''', v_current_partition_id::text, TRUE);
-            IF (NEW.'||v_control||' % '||v_part_interval||') > ('||v_part_interval||' / 2) THEN
+            IF (NEW.'||v_control||' % '||v_part_interval||') >= ('||v_part_interval||' / 2) THEN
                 v_id_position := (length(v_last_partition) - position(''p_'' in reverse(v_last_partition))) + 2;
                 v_last_partition_id = substring(v_last_partition from v_id_position)::bigint;
                 v_next_partition_id := v_last_partition_id + '||v_part_interval||';


### PR DESCRIPTION
New partition will never be created using "(NEW.'||v_control||' % '||v_part_interval||') > ('||v_part_interval||' / 2) THEN)" logic if partition step (v_part_interval) is 1, so changed the conditions to ">=".
