### PR TITLE
Fixed pattern for parent matching in reapply_indexes.py

### DIFF
--- a/bin/reapply_indexes.py
+++ b/bin/reapply_indexes.py
@@ -46,7 +46,7 @@ def create_index(conn, partman_schema, child_schemaname, child_tablename, child_
     parent_schemaname = result[0]
     parent_tablename = result[1]
     cur.close()
-    parent_match_regex = re.compile(r" ON \"?%s\"?\.\"?%s\"? | ON \"?%s\"" % (parent_schemaname, parent_tablename, parent_tablename))
+    parent_match_regex = re.compile(r" ON \"?%s\"?\.\"?%s\"? | ON \"?%s\"?" % (parent_schemaname, parent_tablename, parent_tablename))
     index_match_regex = re.compile(r'(?P<index_def>USING .*)')
     for i in parent_index_list:
         # if there is already a child index that matches the parent index don't try to create it unless --recreate_all set


### PR DESCRIPTION
Fixed indexes being applied to the parent table instead of the children in reapply_indexes.py