### PR TITLE
Fix conflict with intarray extension

### DIFF
--- a/sql/functions/apply_constraints.sql
+++ b/sql/functions/apply_constraints.sql
@@ -191,7 +191,7 @@ LOOP
         AND con.conname LIKE 'partmanconstr_%'
         AND con.contype = 'c' 
         AND a.attname = v_col
-        AND ARRAY[a.attnum] <@ con.conkey 
+        AND ARRAY[a.attnum] OPERATOR(pg_catalog.<@) con.conkey 
         AND a.attisdropped = false;
 
     IF v_jobmon_schema IS NOT NULL THEN

--- a/sql/functions/drop_constraints.sql
+++ b/sql/functions/drop_constraints.sql
@@ -66,7 +66,7 @@ LOOP
         AND con.conname LIKE 'partmanconstr_%'
         AND con.contype = 'c' 
         AND a.attname = v_col
-        AND ARRAY[a.attnum] <@ con.conkey 
+        AND ARRAY[a.attnum] OPERATOR(pg_catalog.<@) con.conkey 
         AND a.attisdropped = false;
 
     IF v_existing_constraint_name IS NOT NULL THEN


### PR DESCRIPTION
Without this fix, applying and dropping constraints does not work if the intarray extension is in the search path:
```
ERROR:  operator is not unique: smallint[] <@ smallint[]
LINE xx:         AND ARRAY[a.attnum] <@ con.conkey
```