### PR TITLE
Use bigint instead of int for partition id in apply_constraints

### DIFF
--- a/sql/functions/apply_constraints.sql
+++ b/sql/functions/apply_constraints.sql
@@ -25,7 +25,7 @@ v_job_id                        bigint;
 v_jobmon                        boolean;
 v_jobmon_schema                 text;
 v_last_partition                text;
-v_last_partition_id             int; 
+v_last_partition_id             bigint;
 v_last_partition_timestamp      timestamp;
 v_max_id                        bigint;
 v_max_timestamp                 timestamp;
@@ -38,7 +38,6 @@ v_partition_suffix              text;
 v_row_max                       record;
 v_sql                           text;
 v_step_id                       bigint;
-v_suffix_position               int;
 v_type                          text;
 
 BEGIN


### PR DESCRIPTION
Fixes:
```
ERROR:  value "5499000000" is out of range for type integer
CONTEXT: PL/pgSQL function partman.apply_constraints(text,text,boolean,bigint,boolean) line 108 at SQL statement
```
I did a quick audit to see if this was an issue elsewhere and it doesn't appear to be.