### PR TITLE
Fix security definer security issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ignore/*
 .deps/*
 *.o
 *.so
+sql/pg_partman--*.sql

--- a/sql/functions/apply_cluster.sql
+++ b/sql/functions/apply_cluster.sql
@@ -2,8 +2,8 @@
 * Function to apply cluster from parent to child table
 * Adapted from code fork by https://github.com/dturon/pg_partman
 */
-CREATE FUNCTION apply_cluster(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+CREATE FUNCTION @extschema@.apply_cluster(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
 AS $$
 DECLARE
     v_parent_indexdef   text;

--- a/sql/functions/apply_privileges.sql
+++ b/sql/functions/apply_privileges.sql
@@ -2,7 +2,7 @@
  * Apply privileges that exist on a given parent to the given child table
  */
 CREATE FUNCTION apply_privileges(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text, p_job_id bigint DEFAULT NULL) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/check_name_length.sql
+++ b/sql/functions/check_name_length.sql
@@ -3,8 +3,8 @@
  * Also appends given suffix and schema if given and truncates the name so that the entire suffix will fit.
  * Returns original name with schema given if it doesn't require truncation
  */
-CREATE FUNCTION check_name_length (p_object_name text, p_suffix text DEFAULT NULL, p_table_partition boolean DEFAULT FALSE) RETURNS text
-    LANGUAGE plpgsql SECURITY DEFINER
+CREATE FUNCTION @extschema@.check_name_length (p_object_name text, p_suffix text DEFAULT NULL, p_table_partition boolean DEFAULT FALSE) RETURNS text
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
     v_new_length    int;

--- a/sql/functions/check_parent.sql
+++ b/sql/functions/check_parent.sql
@@ -2,7 +2,7 @@
  * Function to monitor for data getting inserted into parent tables managed by extension
  */
 CREATE FUNCTION check_parent() RETURNS SETOF @extschema@.check_parent_table
-    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/check_subpart_sameconfig.sql
+++ b/sql/functions/check_subpart_sameconfig.sql
@@ -21,7 +21,7 @@ RETURNS TABLE (sub_partition_type text
         , sub_optimize_constraint int
         , sub_infinite_time_partitions boolean
         , sub_jobmon boolean)
-LANGUAGE sql STABLE SECURITY DEFINER
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = @extschema@, pg_temp
 AS $$
 
     WITH parent_info AS (

--- a/sql/functions/create_function_id.sql
+++ b/sql/functions/create_function_id.sql
@@ -2,7 +2,7 @@
  * Create the trigger function for the parent table of an id-based partition set
  */
 CREATE FUNCTION create_function_id(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_function_time.sql
+++ b/sql/functions/create_function_time.sql
@@ -2,7 +2,7 @@
  * Create the trigger function for the parent table of a time-based partition set
  */
 CREATE FUNCTION create_function_time(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -15,7 +15,7 @@ CREATE FUNCTION create_parent(
     , p_jobmon boolean DEFAULT true
     , p_debug boolean DEFAULT false) 
 RETURNS boolean 
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_partition_id.sql
+++ b/sql/functions/create_partition_id.sql
@@ -2,7 +2,7 @@
  * Function to create id partitions
  */
 CREATE FUNCTION create_partition_id(p_parent_table text, p_partition_ids bigint[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS boolean
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -3,7 +3,7 @@
  */
 CREATE FUNCTION create_partition_time(p_parent_table text, p_partition_times timestamp[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) 
 RETURNS boolean
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_sub_parent.sql
+++ b/sql/functions/create_sub_parent.sql
@@ -19,7 +19,7 @@ CREATE FUNCTION create_sub_parent(
     , p_jobmon boolean DEFAULT true
     , p_debug boolean DEFAULT false) 
 RETURNS boolean
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/create_trigger.sql
+++ b/sql/functions/create_trigger.sql
@@ -1,5 +1,5 @@
 CREATE FUNCTION create_trigger(p_parent_table text) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/drop_partition_id.sql
+++ b/sql/functions/drop_partition_id.sql
@@ -3,7 +3,7 @@
  * Options to move table to different schema, drop only indexes or actually drop the table from the database.
  */
 CREATE FUNCTION drop_partition_id(p_parent_table text, p_retention bigint DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/drop_partition_time.sql
+++ b/sql/functions/drop_partition_time.sql
@@ -3,7 +3,7 @@
  * Options to move table to different schema, drop only indexes or actually drop the table from the database.
  */
 CREATE FUNCTION drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/partition_data_id.sql
+++ b/sql/functions/partition_data_id.sql
@@ -2,7 +2,7 @@
  * Populate the child table(s) of an id-based partition set with old data from the original parent
  */
 CREATE FUNCTION partition_data_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval int DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -2,7 +2,7 @@
  * Populate the child table(s) of a time-based partition set with old data from the original parent
  */
 CREATE FUNCTION partition_data_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/reapply_privileges.sql
+++ b/sql/functions/reapply_privileges.sql
@@ -2,7 +2,7 @@
  * Function to re-apply ownership & privileges on all child tables in a partition set using parent table as reference
  */
 CREATE FUNCTION reapply_privileges(p_parent_table text) RETURNS void
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -7,7 +7,7 @@
  * Be aware that constraint exclusion may not work properly until an analyze on the partition set is run. 
  */
 CREATE FUNCTION run_maintenance(p_parent_table text DEFAULT NULL, p_analyze boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS void 
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/show_partition_info.sql
+++ b/sql/functions/show_partition_info.sql
@@ -7,7 +7,7 @@ CREATE FUNCTION show_partition_info(p_child_table text
     , OUT child_end_id bigint 
     , OUT suffix text)
 RETURNS record
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/show_partitions.sql
+++ b/sql/functions/show_partitions.sql
@@ -2,7 +2,7 @@
  * Function to list all child partitions in a set.
  */
 CREATE FUNCTION show_partitions (p_parent_table text, p_order text DEFAULT 'ASC') RETURNS TABLE (partition_schemaname text, partition_tablename text)
-    LANGUAGE plpgsql STABLE SECURITY DEFINER 
+    LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = @extschema@, pg_temp 
     AS $$
 DECLARE
 

--- a/sql/functions/undo_partition.sql
+++ b/sql/functions/undo_partition.sql
@@ -3,7 +3,7 @@
  * Will actually work on any parent/child table set, not just ones created by pg_partman.
  */
 CREATE FUNCTION undo_partition(p_parent_table text, p_batch_count int DEFAULT 1, p_keep_table boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/undo_partition_id.sql
+++ b/sql/functions/undo_partition_id.sql
@@ -2,7 +2,7 @@
  * Function to undo id-based partitioning created by this extension
  */
 CREATE FUNCTION undo_partition_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval bigint DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/functions/undo_partition_time.sql
+++ b/sql/functions/undo_partition_time.sql
@@ -2,7 +2,7 @@
  * Function to undo time-based partitioning created by this extension
  */
 CREATE FUNCTION undo_partition_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint 
-    LANGUAGE plpgsql SECURITY DEFINER
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 

--- a/sql/tables/tables.sql
+++ b/sql/tables/tables.sql
@@ -61,7 +61,7 @@ SELECT pg_catalog.pg_extension_config_dump('custom_time_partitions', '');
  * Check function for config table partition types
  */
 CREATE FUNCTION @extschema@.check_partition_type (p_type text) RETURNS boolean
-    LANGUAGE plpgsql IMMUTABLE SECURITY DEFINER
+    LANGUAGE plpgsql IMMUTABLE SECURITY DEFINER SET search_path = @extschema@, pg_temp
     AS $$
 DECLARE
 v_result    boolean;

--- a/test/README_test.md
+++ b/test/README_test.md
@@ -13,6 +13,10 @@ Tests assume that the required extensions have been installed in the following s
 If you've installed any of the above extensions in a different schema and would like to run the test suite, simply change the configuration option found at the top of each testing file to match your setup. If you've also installed pg_jobmon, be aware that the logging of the tests cannot be rolled back and any failures will be picked up by the monitoring in the jobmon extension.
 
     SELECT set_config('search_path','partman, public',false);
+
+
+There are two simple helper scripts:
+The `init-and-start.sh` creates and starts a simple cluster test cluster, `stop-and-destroy.sh` stops and destroys it.
     
 Once that's done, it's best to use the **pg_prove** script that pgTAP comes with to run all the tests. I like using the  -o -f -v options to get more useful feedback.
 

--- a/test/init-and-start.sh
+++ b/test/init-and-start.sh
@@ -1,6 +1,8 @@
-#
-# Install and start a simple test cluster  
-#
+#!/bin/sh
+
+
+echo "Install and start a simple PostgreSQL cluster for testing"
+
 
 initdb -D /tmp/pgtest
 echo "shared_preload_libraries = 'pg_partman_bgw'" >/tmp/pgtest/postgresql.conf
@@ -19,3 +21,8 @@ echo "  pg_prove -d postgres -ovf tests/*.sql"
 echo 
 echo "stop all with: pg_ctl -D /tmp/pgtest stop && rm -rvf /tmp/pgtest"
 
+test/test-id-id-id-subpart.sql            (Wstat: 768 Tests: 1508 Failed: 0)
+  Non-zero exit status: 3
+  Parse errors: Bad plan.  You planned 3096 tests but ran 1508.
+test/test-time-weekly-daily-subpart.sql   (Wstat: 0 Tests: 278 Failed: 4)
+  Failed tests:  169-171, 173

--- a/test/init.sh
+++ b/test/init.sh
@@ -1,6 +1,6 @@
---
--- Install and start a simple test cluster  
---
+#
+# Install and start a simple test cluster  
+#
 
 initdb -D /tmp/pgtest
 echo "shared_preload_libraries = 'pg_partman_bgw'" >/tmp/pgtest/postgresql.conf

--- a/test/init.sh
+++ b/test/init.sh
@@ -1,0 +1,21 @@
+--
+-- Install and start a simple test cluster  
+--
+
+initdb -D /tmp/pgtest
+echo "shared_preload_libraries = 'pg_partman_bgw'" >/tmp/pgtest/postgresql.conf
+
+pg_ctl -D /tmp/pgtest start
+
+echo "Postgres started; wait for startup.";
+sleep 2
+
+psql -c 'CREATE SCHEMA partman; CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman; CREATE EXTENSION IF NOT EXISTS pgtap;' postgres
+
+
+echo "Postgres running (unless there are error mesages). Start testing with"
+echo 
+echo "  pg_prove -d postgres -ovf tests/*.sql"
+echo 
+echo "stop all with: pg_ctl -D /tmp/pgtest stop && rm -rvf /tmp/pgtest"
+

--- a/test/stop-and-destroy.sh
+++ b/test/stop-and-destroy.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Stop Test-PostgresSQL and destroy cluster"
+
+pg_ctl -D /tmp/pgtest -m fast stop
+rm -rvf /tmp/pgtest
+

--- a/test/test-security--security-definer.sql
+++ b/test/test-security--security-definer.sql
@@ -1,0 +1,78 @@
+--
+-- Testet, ob alle Funktionen mit SECURITY DEFINER auch den Suchpfad
+-- mit pg_temp am Ende gesetzt haben 
+--
+-- Aus Sicherheitsgründen MUSS pg_temp bei diesen Funktionen gesetzt werden.
+-- Siehe
+-- http://www.postgresql.org/docs/current/static/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY
+--
+
+
+BEGIN;
+
+-- 
+-- main function, because conditional plan
+--
+
+CREATE FUNCTION run_secdef_check() 
+   RETURNS SETOF text 
+   LANGUAGE plpgsql
+   AS
+   $code$
+   DECLARE cnt INTEGER;
+   DECLARE r   RECORD;
+   BEGIN
+   
+      CREATE TEMPORARY TABLE secfunc AS 
+        (
+          SELECT nspname || '.' || proname AS name, 
+                 proconfig,
+                 prosecdef
+            FROM pg_proc p
+       LEFT JOIN pg_namespace n ON pronamespace = n.oid
+           WHERE prosecdef
+             AND nspname NOT LIKE 'pg_%'
+        ORDER BY name
+         );
+         
+      SELECT INTO cnt count(*)::INTEGER FROM secfunc;
+      IF cnt = 0 THEN
+         RETURN NEXT plan(1);
+         RETURN NEXT skip('No security definer function.');
+      ELSE
+         RETURN NEXT plan(cnt);
+         FOR r IN 
+
+            -- TODO:
+            -- this is hacky and may fail because only simple regex check 
+            -- when there are other parameters set.
+            -- Change this to strip down all array elements of proconfig etc!
+            -- 
+
+            SELECT matches(
+               proconfig::text,
+               E'search_path=[^=]+pg_temp"?}',
+               'Function ' || name || ' using SECURITY DEFINER needs pg_temp at last position in search_path'
+               ) 
+               FROM secfunc
+         LOOP
+            RETURN NEXT r;
+         END LOOP;
+
+      END IF;
+      
+      RETURN;
+      
+   END
+      
+   $code$;
+
+
+SELECT * FROM run_secdef_check();
+
+
+
+-- Finish the tests and clean up.
+SELECT * FROM finish();
+ROLLBACK;
+


### PR DESCRIPTION
The following changes fixes a security issue with all functions using `SECURITY DEFINER` and adds a test for this case.

While running my test suite for an other project, I recognized that all functions with `SECURITY DEFINER` are created in a way, an attacker can misuse it.

For details see [Writing SECURITY DEFINER Functions Safely](http://www.postgresql.org/docs/current/static/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY) in the PostgreSQL documentation.

This pull request contains all changes and a test in `test/test-security--security-definer.sql` for this.

The fix is, that all `SECURITY DEFINER` functions need an explicit secure search path with pg_temp at the end. I added this in all functions.

Beside this, I include a very simple init&start script to start a test instance from scratch and a fix for `.gitignore`, which now includes the compiled SQL.


All tests are OK (tested with PostgreSQL 9.5), beside some tests which fail in the same way without my changes:

```
test/test-id-id-id-subpart.sql            (Wstat: 768 Tests: 1508 Failed: 0)
  Non-zero exit status: 3
  Parse errors: Bad plan.  You planned 3096 tests but ran 1508.
test/test-time-weekly-daily-subpart.sql   (Wstat: 0 Tests: 278 Failed: 4)
  Failed tests:  169-171, 173
```
