### PR TITLE
Fix check_parent for large databases

### DIFF
--- a/sql/functions/check_parent.sql
+++ b/sql/functions/check_parent.sql
@@ -1,7 +1,7 @@
 /*
  * Function to monitor for data getting inserted into parent tables managed by extension
  */
-CREATE FUNCTION check_parent() RETURNS SETOF @extschema@.check_parent_table
+CREATE FUNCTION check_parent(p_exact_count boolean DEFAULT true) RETURNS SETOF @extschema@.check_parent_table
     LANGUAGE plpgsql STABLE SECURITY DEFINER
     AS $$
 DECLARE
@@ -24,7 +24,11 @@ LOOP
     WHERE schemaname = split_part(v_row.parent_table, '.', 1)::name
     AND tablename = split_part(v_row.parent_table, '.', 2)::name;
 
-    v_sql := format('SELECT count(1) AS n FROM ONLY %I.%I', v_schemaname, v_tablename);
+    IF p_exact_count THEN
+        v_sql := format('SELECT count(1) AS n FROM ONLY %I.%I', v_schemaname, v_tablename);
+    ELSE
+        v_sql := format('SELECT count(1) AS n FROM (SELECT * FROM ONLY %I.%I LIMIT 1) x', v_schemaname, v_tablename);
+    END IF;
 
     -- Each query creates an AccessShareLock on referenced table (along with all of its indexes)
     -- that PostgreSQL holds until parent transaction block COMMITs or ROLLBACKs, which can lead

--- a/sql/functions/check_parent.sql
+++ b/sql/functions/check_parent.sql
@@ -16,7 +16,7 @@ v_trouble       @extschema@.check_parent_table%rowtype;
 BEGIN
 
 FOR v_row IN 
-    SELECT DISTINCT parent_table FROM @extschema@.part_config
+    SELECT parent_table FROM @extschema@.part_config
 LOOP
     SELECT schemaname, tablename 
     INTO v_schemaname, v_tablename
@@ -25,16 +25,25 @@ LOOP
     AND tablename = split_part(v_row.parent_table, '.', 2)::name;
 
     v_sql := format('SELECT count(1) AS n FROM ONLY %I.%I', v_schemaname, v_tablename);
-    EXECUTE v_sql INTO v_count;
+
+    -- Each query creates an AccessShareLock on referenced table (along with all of its indexes)
+    -- that PostgreSQL holds until parent transaction block COMMITs or ROLLBACKs, which can lead
+    -- to an 'out of shared memory' error. PL/pgSQL disallows SAVEPOINTs in PL/pgSQL,
+    -- but we can simulate ROLLBACK TO SAVEPOINT by throwing an exception within BEGIN...END block.
+    BEGIN
+        v_count := 0;
+        EXECUTE v_sql INTO v_count;
+        RAISE EXCEPTION USING errcode = 'PMRLB';
+    EXCEPTION
+        WHEN sqlstate 'PMRLB' THEN
+            NULL;
+    END;
 
     IF v_count > 0 THEN 
         v_trouble.parent_table := v_schemaname ||'.'|| v_tablename;
         v_trouble.count := v_count;
         RETURN NEXT v_trouble;
     END IF;
-
-    v_count := 0;
-
 END LOOP;
 
 RETURN;


### PR DESCRIPTION
When partman manages lots of tables it can fail with "out of shared memory" error because each `SELECT count(1)...` query creates an AccessShareLock and PostgreSQL keeps them until the end of session. In my case it breaks somewhere around 1550th table.

I made a workaround that uses BEGIN..END block with exceptions to simulate a SAVEPOINT...ROLLBACK sequence that allows PostgreSQL to release these locks.

A second change is an option to stop counting after first record in parent table is found. When I am looking for tables to fix with partition_data.py it doesn't matter how many records are there - it's only important to find tables that need attention.

I made a test with 1000 empty, partitioned tables - both versions (before and after my changes) run within 1.2s, so there's no easily measurable overhead due to throwing exceptions and doing rollbacks after each parent is checked.