### PR TITLE
Added p_analyze parameter to create_function_id, create_parent, parti…

### DIFF
--- a/sql/functions/create_function_id.sql
+++ b/sql/functions/create_function_id.sql
@@ -1,7 +1,7 @@
 /*
  * Create the trigger function for the parent table of an id-based partition set
  */
-CREATE FUNCTION create_function_id(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
+CREATE FUNCTION create_function_id(p_parent_table text, p_job_id bigint DEFAULT NULL, p_analyze boolean DEFAULT true) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE
@@ -240,9 +240,9 @@ v_trig_func := format('CREATE OR REPLACE FUNCTION %I.%I() RETURNS trigger LANGUA
             v_id_position := (length(v_last_partition) - position(''p_'' in reverse(v_last_partition))) + 2;
             v_next_partition_id := (substring(v_last_partition from v_id_position)::bigint) + %s;
             WHILE ((v_next_partition_id - v_current_partition_id) / %s) <= %s LOOP 
-                v_partition_created := @extschema@.create_partition_id(%L, ARRAY[v_next_partition_id]);
+                v_partition_created := @extschema@.create_partition_id(%L, ARRAY[v_next_partition_id], %L::boolean );
                 IF v_partition_created THEN
-                    PERFORM @extschema@.create_function_id(%L);
+                    PERFORM @extschema@.create_function_id(%L, NULL, %L::boolean);
                     PERFORM @extschema@.apply_constraints(%L);
                 END IF;
                 v_next_partition_id := v_next_partition_id + %s;
@@ -258,7 +258,9 @@ v_trig_func := format('CREATE OR REPLACE FUNCTION %I.%I() RETURNS trigger LANGUA
             , v_partition_interval
             , v_premake
             , p_parent_table
+            , p_analyze
             , p_parent_table
+            , p_analyze
             , p_parent_table
             , v_partition_interval
         );

--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -15,7 +15,8 @@ CREATE FUNCTION create_parent(
     , p_upsert text DEFAULT ''
     , p_trigger_return_null boolean DEFAULT true
     , p_jobmon boolean DEFAULT true
-    , p_debug boolean DEFAULT false) 
+    , p_debug boolean DEFAULT false
+    , p_analyze boolean DEFAULT true) 
 RETURNS boolean 
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
@@ -502,7 +503,7 @@ IF p_type = 'time' OR p_type = 'time-custom' THEN
         PERFORM update_step(v_step_id, 'OK', 'Time function created');
     END IF;
 ELSIF p_type = 'id' THEN
-    PERFORM @extschema@.create_function_id(p_parent_table, v_job_id);  
+    PERFORM @extschema@.create_function_id(p_parent_table, v_job_id, p_analyze);  
     IF v_jobmon_schema IS NOT NULL THEN
         PERFORM update_step(v_step_id, 'OK', 'ID function created');
     END IF;

--- a/sql/functions/partition_data_id.sql
+++ b/sql/functions/partition_data_id.sql
@@ -1,7 +1,7 @@
 /*
  * Populate the child table(s) of an id-based partition set with old data from the original parent
  */
-CREATE FUNCTION partition_data_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval bigint DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
+CREATE FUNCTION partition_data_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval bigint DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC', p_analyze boolean DEFAULT true) RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE
@@ -108,7 +108,7 @@ FOR i IN 1..p_batch_count LOOP
         END IF;
     END IF;
 
-    PERFORM @extschema@.create_partition_id(p_parent_table, v_partition_id);
+    PERFORM @extschema@.create_partition_id(p_parent_table, v_partition_id, p_analyze);
     v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_min_partition_id::text, TRUE);
 
     EXECUTE format('WITH partition_data AS (
@@ -131,7 +131,7 @@ FOR i IN 1..p_batch_count LOOP
 
 END LOOP;
 
-PERFORM @extschema@.create_function_id(p_parent_table);
+PERFORM @extschema@.create_function_id(p_parent_table, NULL, p_analyze);
 
 EXECUTE format('SELECT set_config(%L, %L, %L)', 'search_path', v_old_search_path, 'false');
 

--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -1,7 +1,7 @@
 /*
  * Populate the child table(s) of a time-based partition set with old data from the original parent
  */
-CREATE FUNCTION partition_data_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
+CREATE FUNCTION partition_data_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC', p_analyze boolean DEFAULT true) RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE
@@ -195,7 +195,7 @@ FOR i IN 1..p_batch_count LOOP
         END IF;
     END IF;
 
-    PERFORM @extschema@.create_partition_time(p_parent_table, v_partition_timestamp);
+    PERFORM @extschema@.create_partition_time(p_parent_table, v_partition_timestamp, p_analyze);
     -- This suffix generation code is in create_partition_time() as well
     v_partition_suffix := to_char(v_min_partition_timestamp, v_datetime_string);
     v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -286,7 +286,7 @@ LOOP
             v_last_partition_created := @extschema@.create_partition_id(v_row.parent_table, ARRAY[v_next_partition_id], p_analyze);
             IF v_last_partition_created THEN
                 v_create_count := v_create_count + 1;
-                PERFORM @extschema@.create_function_id(v_row.parent_table, v_job_id);
+                PERFORM @extschema@.create_function_id(v_row.parent_table, v_job_id, p_analyze);
             END IF;
             v_premade_count := ((v_next_partition_id - v_current_partition_id) / v_row.partition_interval::bigint);
         END LOOP;
@@ -326,7 +326,7 @@ LOOP
         END IF;
     END IF;
     IF v_drop_count > 0 THEN
-        PERFORM @extschema@.create_function_id(v_row.parent_table, v_job_id);
+        PERFORM @extschema@.create_function_id(v_row.parent_table, v_job_id, p_analyze);
     END IF;
 END LOOP; 
 


### PR DESCRIPTION
Added p_analyze parameter to create_function_id, create_parent, partition_data_id and partition_data_time to be able to control if the analyze should run when a new child table is created.

We have the problem that when a new sub partition is created a ANALYZE is run on the parent table and when this is performed the table is locked and the analyze will take very long time and not allowing us to use the table at all, when running the analyze manually the table is not locked.

Now I added parameter to all places that I could find where a call to create_partition_id or create_partition_time is potentially invoked to make sure that it is possible to disable the analyze no matter how the new sub_table is created.
