### PR TITLE
table_privs using information_schema.table_privileges instead of pg_authid

### DIFF
--- a/sql/tables/tables.sql
+++ b/sql/tables/tables.sql
@@ -99,28 +99,4 @@ ALTER TABLE @extschema@.part_config_sub ADD CONSTRAINT control_constraint_col_ch
  * information_schema is a performance bottleneck since indexes aren't being used properly.
  */
 CREATE VIEW @extschema@.table_privs AS
-    SELECT u_grantor.rolname AS grantor,
-           grantee.rolname AS grantee,
-           nc.nspname AS table_schema,
-           c.relname AS table_name,
-           c.prtype AS privilege_type
-    FROM (
-            SELECT oid, relname, relnamespace, relkind, relowner, (aclexplode(coalesce(relacl, acldefault('r', relowner)))).* FROM pg_class
-         ) AS c (oid, relname, relnamespace, relkind, relowner, grantor, grantee, prtype, grantable),
-         pg_namespace nc,
-         pg_authid u_grantor,
-         (
-           SELECT oid, rolname FROM pg_authid
-           UNION ALL
-           SELECT 0::oid, 'PUBLIC'
-         ) AS grantee (oid, rolname)
-    WHERE c.relnamespace = nc.oid
-          AND c.relkind IN ('r', 'v')
-          AND c.grantee = grantee.oid
-          AND c.grantor = u_grantor.oid
-          AND c.prtype IN ('INSERT', 'SELECT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER')
-          AND (pg_has_role(u_grantor.oid, 'USAGE')
-               OR pg_has_role(grantee.oid, 'USAGE')
-               OR grantee.rolname = 'PUBLIC' );
-
-
+SELECT grantor::name,grantee::name,table_schema::name,table_name::name,privilege_type::text FROM information_schema.table_privileges;


### PR DESCRIPTION
Changing view table_privs in order to avoid permission problems on pg_authid table. It makes possible to use pg_partman in Amazon RDS databases.

In Amazon RDS the user available doesn't have permissions to view pg_authid catalog table. 

This change leverage the view information_schema.table_privileges. 