### PR TITLE
Support pg16 with background worker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 4.7.4
 NEW FEATURES
 ============
--- Compatible with PostgreSQL 15.
+-- Compatible with PostgreSQL 16.
 
 
 4.7.3

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+4.7.4
+NEW FEATURES
+============
+-- Compatible with PostgreSQL 15.
+
+
 4.7.3
 BUG FIXES
 =========

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
     "name": "pg_partman",
     "abstract": "Extension to manage partitioned tables by time or ID",
-    "version": "4.7.3",
+    "version": "4.7.4",
     "maintainer": [ 
         "Keith Fiske <keith@keithf4.com>"
     ],
@@ -20,9 +20,9 @@
     },
     "provides": {
         "pg_partman": {
-            "file": "sql/pg_partman--4.7.3.sql",
+            "file": "sql/pg_partman--4.7.4.sql",
             "docfile": "doc/pg_partman.md",
-            "version": "4.7.3",
+            "version": "4.7.4",
             "abstract": "Extension to manage partitioned tables by time or ID"
         }
     },

--- a/pg_partman.control
+++ b/pg_partman.control
@@ -1,3 +1,3 @@
-default_version = '4.7.3'
+default_version = '4.7.4'
 comment = 'Extension to manage partitioned tables by time or ID'
 relocatable = false

--- a/updates/pg_partman--4.7.3--4.7.4.sql
+++ b/updates/pg_partman--4.7.3--4.7.4.sql
@@ -1,0 +1,4 @@
+-- NOTE: No changes to the sql extension code contained in this update. This file is only here for version upgrade continuity.
+
+-- Add support for PostgreSQL 16 (Github PR #508)
+-- Update doc formatting (Github PR #547)


### PR DESCRIPTION
PG 16 support had already been committed into master branch. Cut a release for it before 5.x