### PR TITLE
Avoid scanning non-default partitions

### DIFF
--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -219,7 +219,7 @@ LOOP
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP
-            EXECUTE format('SELECT max(%s)::text FROM %I.%I'
+            EXECUTE format('SELECT %s::text FROM %I.%I LIMIT 1'
                                 , v_partition_expression
                                 , v_row_max_time.partition_schemaname
                                 , v_row_max_time.partition_tablename

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -214,7 +214,7 @@ LOOP
         -- Must be reset to null otherwise if the next partition set in the loop is empty, the previous partition set's value could be used
         v_current_partition_timestamp := NULL;
 
-        -- Loop through child tables starting from highest to get current max value in partition set
+        -- Loop through child tables starting from highest to get a timestamp from the highest non-empty partition in the set
         -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
@@ -238,7 +238,7 @@ LOOP
         END LOOP;
         IF v_row.infinite_time_partitions AND v_child_timestamp IS NULL THEN
             -- If partition set is completely empty, still keep making child tables anyway
-            -- Has to be separate check outside above loop since "future" tables are likely going to be empty and make max value in that loop NULL
+            -- Has to be separate check outside above loop since "future" tables are likely going to be empty, hence ignored in that loop
             v_current_partition_timestamp = CURRENT_TIMESTAMP;
         END IF;
 


### PR DESCRIPTION
This is a minimal change to address #660.
It changes one query from selecting the max timestamp in a given partition (which may incur a full table scan) to selecting any timestamp (which should be fast).

**Testing.** I tested it with:

```
pg_prove -U $myuser -d $mydb -ovf test/*.sql
```

**Proof.** I'll argue that the query change does not change the behavior of the function.

Let P be the partition being iterated on.

If it's empty, then `v_max_timestamp` evaluates to null in both old and new code, and the loop iteration does nothing in both old and new code.

Let's then consider a non empty partition P.
Let A (for any timestamp) be the timestamp returned by the new code, and let M (for max) be that returned by the old code.
We have A <= M.

If A >= CURRENT_TIMESTAMP then `show_partition_name` gives back P for both old and new code. (Using A or M doesn't make a difference, as they're both in P.)

Let's look at the case when A < CURRENT_TIMESTAMP.
If also M < CURRENT_TIMESTAMP, both the old and the new code would use CURRENT_TIMESTAMP, so no difference.

It remans to consider the case

    A < CURRENT_TIMESTAMP <= M,

in which case CURRENT_TIMESTAMP still belongs to partition P, so the old code (uses M) and the new code (uses CURRENT_TIMESTAMP) both return P.

