### PR TITLE
feat: process table columns with GENERATED ALWAYS for partition_data_id() and partition_data_time()

### DIFF
--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -39,6 +39,8 @@ v_source_tablename          text;
 v_rowcount                  bigint;
 v_start_control             timestamptz;
 v_total_rows                bigint := 0;
+v_has_identity_column       boolean;
+v_override_clause           text := '';
 
 BEGIN
 /*
@@ -237,6 +239,11 @@ FOR i IN 1..p_batch_count LOOP
     v_partition_suffix := to_char(v_min_partition_timestamp, v_datetime_string);
     v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);
 
+    v_has_identity_column := table_has_identity_columns(v_parent_schema || '.' || v_parent_tablename, p_ignored_columns);
+    IF v_has_identity_column THEN
+        v_override_clause := 'OVERRIDING SYSTEM VALUE';
+    END IF;
+
     IF v_default_exists THEN
         -- Child tables cannot be created if data that belongs to it exists in the default
         -- Have to move data out to temporary location, create child table, then move it back
@@ -244,23 +251,25 @@ FOR i IN 1..p_batch_count LOOP
         -- Temp table created above to avoid excessive temp creation in loop
         EXECUTE format('WITH partition_data AS (
                 DELETE FROM %1$I.%2$I WHERE %3$s >= %4$L AND %3$s < %5$L RETURNING *)
-            INSERT INTO partman_temp_data_storage (%6$s) SELECT %6$s FROM partition_data'
+            INSERT INTO partman_temp_data_storage (%6$s) %7$s SELECT %6$s FROM partition_data'
             , v_source_schemaname
             , v_source_tablename
             , v_partition_expression
             , v_min_partition_timestamp
             , v_max_partition_timestamp
-            , v_column_list);
+            , v_column_list
+            , v_override_clause);  -- insert "OVERRIDING SYSTEM VALUE" or blank
 
         -- Set analyze to true if a table is created
         v_analyze := @extschema@.create_partition_time(p_parent_table, v_partition_timestamp);
 
         EXECUTE format('WITH partition_data AS (
                 DELETE FROM partman_temp_data_storage RETURNING *)
-            INSERT INTO %I.%I (%3$s) SELECT %3$s FROM partition_data'
+            INSERT INTO %I.%I (%3$s) %4$s SELECT %3$s FROM partition_data'
             , v_parent_schema
             , v_current_partition_name
-            , v_column_list);
+            , v_column_list
+            , v_override_clause);  -- insert "OVERRIDING SYSTEM VALUE" or blank
 
     ELSE
 
@@ -269,7 +278,7 @@ FOR i IN 1..p_batch_count LOOP
 
         EXECUTE format('WITH partition_data AS (
                             DELETE FROM ONLY %I.%I WHERE %s >= %L AND %3$s < %5$L RETURNING *)
-                         INSERT INTO %6$I.%7$I (%8$s) SELECT %8$s FROM partition_data'
+                         INSERT INTO %6$I.%7$I (%8$s) %9$s SELECT %8$s FROM partition_data'
                             , v_source_schemaname
                             , v_source_tablename
                             , v_partition_expression
@@ -277,7 +286,8 @@ FOR i IN 1..p_batch_count LOOP
                             , v_max_partition_timestamp
                             , v_parent_schema
                             , v_current_partition_name
-                            , v_column_list);
+                            , v_column_list
+                            , v_override_clause);  -- insert "OVERRIDING SYSTEM VALUE" or blank
     END IF;
 
     GET DIAGNOSTICS v_rowcount = ROW_COUNT;

--- a/sql/functions/table_has_identity_columns.sql
+++ b/sql/functions/table_has_identity_columns.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION table_has_identity_columns(
+    table_name text,
+    p_ignored_columns text[] DEFAULT NULL
+) RETURNS boolean AS $$
+DECLARE
+    identity_columns_count int;
+    schema_name text;
+    table_only_name text;
+BEGIN
+    -- if table_name contains schema，split schema and table
+    IF table_name LIKE '%.%' THEN
+        schema_name := split_part(table_name, '.', 1);
+        table_only_name := split_part(table_name, '.', 2);
+    ELSE
+        -- if not，use curent schema
+        schema_name := current_schema();
+        table_only_name := table_name;
+    END IF;
+
+    -- query all columns defined with GENERATED ALWAYS AS IDENTITY ，except columns in p_ignored_columns
+    SELECT COUNT(*)
+    INTO identity_columns_count
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = table_only_name
+    AND n.nspname = schema_name
+    AND a.attidentity = 'a'     -- GENERATED ALWAYS AS IDENTITY
+    AND a.attnum > 0            -- except system column
+    AND NOT a.attisdropped      -- except deleted column
+    AND (p_ignored_columns IS NULL OR a.attname != ANY(p_ignored_columns)); 
+
+    IF identity_columns_count > 0 THEN
+        RETURN true;
+    ELSE
+        RETURN false;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/sql/functions/table_has_identity_columns.sql
+++ b/sql/functions/table_has_identity_columns.sql
@@ -1,36 +1,34 @@
 CREATE OR REPLACE FUNCTION table_has_identity_columns(
-    table_name text,
+    p_table_name text,
     p_ignored_columns text[] DEFAULT NULL
 ) RETURNS boolean AS $$
 DECLARE
-    identity_columns_count int;
-    schema_name text;
-    table_only_name text;
+    v_identity_columns_count int;
+    v_schema_name text;
+    v_table_only_name text;
 BEGIN
-    -- if table_name contains schema，split schema and table
-    IF table_name LIKE '%.%' THEN
-        schema_name := split_part(table_name, '.', 1);
-        table_only_name := split_part(table_name, '.', 2);
+    -- if p_table_name contains schema，split schema and table
+    IF p_table_name LIKE '%.%' THEN
+        v_schema_name := split_part(p_table_name, '.', 1);
+        v_table_only_name := split_part(p_table_name, '.', 2);
     ELSE
         -- if not，use curent schema
-        schema_name := current_schema();
-        table_only_name := table_name;
+        v_schema_name := current_schema();
+        v_table_only_name := p_table_name;
     END IF;
 
     -- query all columns defined with GENERATED ALWAYS AS IDENTITY ，except columns in p_ignored_columns
-    SELECT COUNT(*)
-    INTO identity_columns_count
-    FROM pg_attribute a
-    JOIN pg_class c ON c.oid = a.attrelid
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE c.relname = table_only_name
-    AND n.nspname = schema_name
-    AND a.attidentity = 'a'     -- GENERATED ALWAYS AS IDENTITY
-    AND a.attnum > 0            -- except system column
-    AND NOT a.attisdropped      -- except deleted column
-    AND (p_ignored_columns IS NULL OR a.attname != ANY(p_ignored_columns)); 
+    SELECT COUNT(*) INTO v_identity_columns_count FROM pg_attribute a
+      JOIN pg_class c ON c.oid = a.attrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = v_table_only_name
+      AND n.nspname = v_schema_name
+      AND a.attidentity = 'a'     -- GENERATED ALWAYS AS IDENTITY
+      AND a.attnum > 0            -- except system column
+      AND NOT a.attisdropped      -- except deleted column
+      AND (p_ignored_columns IS NULL OR a.attname != ANY(p_ignored_columns));
 
-    IF identity_columns_count > 0 THEN
+    IF v_identity_columns_count > 0 THEN
         RETURN true;
     ELSE
         RETURN false;


### PR DESCRIPTION
columns with GENERATED ALWAYS and can not ignored by param `p_ignored_columns`, eg. PK
workaround:
insert `OVERRIDING SYSTEM VALUE` string into the sql if there is column having def `GENERATED ALWAYS` excepting `p_ignored_columns`.


