### PR TITLE
fix: put template inheritance behind conditional flag to avoid breaking the create parent function 

### DIFF
--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -635,8 +635,9 @@ IF p_default_table THEN
     PERFORM @extschema@.inherit_replica_identity(v_parent_schema, v_parent_tablename, v_default_partition);
 
     -- Manage template inherited properties
-    PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_default_partition);
-
+    IF v_template_tablename IS NOT NULL THEN
+        PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_partition_name);
+    END IF;
 END IF;
 
 


### PR DESCRIPTION
This pull-request should fix the issue highlighted here
https://github.com/pgpartman/pg_partman/issues/761