### PR TITLE
Commiting Changes to handle partition maintenance on Partition table …

### DIFF
--- a/sql/functions/drop_partition_id.sql
+++ b/sql/functions/drop_partition_id.sql
@@ -248,6 +248,12 @@ LOOP
                 IF v_jobmon_schema IS NOT NULL THEN
                     v_step_id := add_step(v_job_id, format('Drop table %s.%s', v_row.partition_schemaname, v_row.partition_tablename));
                 END IF;
+				v_sql := format('ALTER TABLE %I.%I DETACH PARTITION %I.%I'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_row.partition_schemaname
+                , v_row.partition_tablename);
+				EXECUTE v_sql;
                 v_sql := 'DROP TABLE %I.%I';
                 EXECUTE format(v_sql, v_row.partition_schemaname, v_row.partition_tablename);
                 IF v_jobmon_schema IS NOT NULL THEN

--- a/sql/functions/drop_partition_time.sql
+++ b/sql/functions/drop_partition_time.sql
@@ -256,6 +256,12 @@ LOOP
                 IF v_jobmon_schema IS NOT NULL THEN
                     v_step_id := add_step(v_job_id, format('Drop table %s.%s', v_row.partition_schemaname, v_row.partition_tablename));
                 END IF;
+				v_sql := format('ALTER TABLE %I.%I DETACH PARTITION %I.%I'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_row.partition_schemaname
+                , v_row.partition_tablename);
+				EXECUTE v_sql;
                 v_sql := 'DROP TABLE %I.%I';
                 EXECUTE format(v_sql, v_row.partition_schemaname, v_row.partition_tablename);
                 IF v_jobmon_schema IS NOT NULL THEN


### PR DESCRIPTION
Earlier in 4.7.1 we had column in part_config table drop_cascade_Fk, so if the partitioned table on which maintenance was run using run_maintenance, if it had any Reference then those things use to get dropped. But that was not right, I guess that reason it has been removed from 5.1.0 version.  But a new problem comes if partitioned table is being referred then run maintenance will fail. In order to handle this we need to detach partition before dropping it, hence I have made the changes in two place where partition was being dropped, this should work smoothly without any issue even when partition table is being referred by another table.   

had reported this as issue in https://github.com/pgpartman/pg_partman/issues/767 