### PR TITLE
prevent deadlocks by run_maintenance

### DIFF
--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -227,7 +227,7 @@ LOOP
         -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
         -- Lock the parent_table first to prevent deadlocks
         RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
-        PERFORM format('LOCK ''%I.%I''::regclass IN access share mode', v_parent_schema, v_parent_tablename);
+        PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -225,6 +225,9 @@ LOOP
 
         -- Loop through child tables starting from highest to get a timestamp from the highest non-empty partition in the set
         -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
+        -- Lock the parent_table first to prevent deadlocks
+        RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
+        PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -225,6 +225,9 @@ LOOP
 
         -- Loop through child tables starting from highest to get a timestamp from the highest non-empty partition in the set
         -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
+        -- Lock the parent_table first to prevent deadlocks
+        RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
+        PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP
@@ -354,6 +357,9 @@ LOOP
         -- Must be reset to null otherwise if the next partition set in the loop is empty, the previous partition set's value could be used
         v_current_partition_id := NULL;
 
+        -- Lock the parent_table first to prevent deadlocks
+        RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
+        PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_id IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -227,7 +227,7 @@ LOOP
         -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
         -- Lock the parent_table first to prevent deadlocks
         RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
-        PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
+        PERFORM format('LOCK ''%I.%I''::regclass IN access share mode', v_parent_schema, v_parent_tablename);
         FOR v_row_max_time IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
         LOOP
@@ -358,7 +358,7 @@ LOOP
         v_current_partition_id := NULL;
 
         -- Lock the parent_table first to prevent deadlocks
-        RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
+        RAISE DEBUG 'PERFORM LOCK %.% IN access share mode', v_parent_schema, v_parent_tablename;
         PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_id IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -358,7 +358,7 @@ LOOP
         v_current_partition_id := NULL;
 
         -- Lock the parent_table first to prevent deadlocks
-        RAISE DEBUG 'PERFORM LOCK %.% IN access share mode', v_parent_schema, v_parent_tablename;
+        RAISE DEBUG 'PERFORM LOCK %.%', v_parent_schema, v_parent_tablename;
         PERFORM format('LOCK ''%I.%I''::regclass', v_parent_schema, v_parent_tablename);
         FOR v_row_max_id IN
             SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)


### PR DESCRIPTION
run_maintenance locks partitions first. This is opposite to common table access and causes deadlocks.
This patch locks the parent table before the partitions are accessed.