### PR TITLE
Add missing plpgsql dependency to pg_partman.control

### DIFF
--- a/pg_partman.control
+++ b/pg_partman.control
@@ -2,3 +2,4 @@ default_version = '5.2.4'
 comment = 'Extension to manage partitioned tables by time or ID'
 relocatable = false
 superuser = false
+requires = 'plpgsql'


### PR DESCRIPTION
## Problem

While trying to install `pg_partman` with `CREATE EXTENSION pg_partman CASCADE` in a database where the `plpgsql` extension had been dropped, I encountered the following error:
```text
failed to create 'pg_partman' extension: pq: language "plpgsql" does not exist
```

[PostgreSQL documentation states](https://www.postgresql.org/docs/current/plpgsql-overview.html) that PL/pgSQL is installed by default in every database. However, users can still remove it via `DROP EXTENSION plpgsql`. In that case, installing `pg_partman` fails because the dependency is not declared.

It is also worth noting that other extensions commonly declare plpgsql in their requires field (see [examples on GitHub](https://github.com/search?q=path%3A*.control+%22requires%22+AND+plpgsql&type=code&p=1)).

## Fix

This PR adds
```text
requires = 'plpgsql'
```

to `pg_partman.control`, ensuring that `plpgsql` is automatically installed when creating `pg_partman`.