### PR TITLE
Refine tag matching in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    tags: [v*]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 jobs:
   release:
     name: Release on PGXN


### PR DESCRIPTION
Improve the `on.push.tags` entry in `.github/workflows/release.yml` to use a regular expression that matches only non-pre-release semantic version tags. This should prevent it from releasing a prerelease on PGXN. It will need refining should the desire arise to put prerelease versions on PGXN.