### PR TITLE
Fix missing function name in pg_partman.md

### DIFF
--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -192,7 +192,7 @@ As a note for people that were not aware, you can name arguments in function cal
 
 <a id="create_partition"></a>
 ```sql
-
+create_partition(
     p_parent_table text
     , p_control text
     , p_interval text


### PR DESCRIPTION
The function name in the `create_partition` signature example was missing and caused me some minor cognitive consternation.